### PR TITLE
Fix centurion boarding message in log

### DIFF
--- a/DeckManagerOutput/GameWindow.cs
+++ b/DeckManagerOutput/GameWindow.cs
@@ -384,7 +384,7 @@ namespace DeckManagerOutput
         private void AddCenturionToBoardingTrackToolStripMenuItemClick(object sender, EventArgs e)
         {
             Program.GManager.CurrentGameState.CylonBoarding[0] += 1;
-            Program.GManager.CurrentGameState.TurnLog += Resources.CenturionBoardsGalactica;
+            Program.GManager.AddToTurnLog(Resources.CenturionBoardsGalactica);
             RefreshCenturionBoardingTrack();
         }
 


### PR DESCRIPTION
Modifying the TurnLog directly was resulting in a lack of newline, which for whatever reason was causing the first word of the next log message to be eaten.

This fixes that.
